### PR TITLE
Fix leftwm-theme update --no-list

### DIFF
--- a/src/operations/update.rs
+++ b/src/operations/update.rs
@@ -39,7 +39,7 @@ impl Update {
             Config::save(&config)?;
         }
 
-        if !self.no_fetch {
+        if !self.no_list {
             //List themes
             println!("{}", "\nAvailable themes:".bright_blue().bold());
 


### PR DESCRIPTION
The wrong condition was being checked, so `leftwm-theme update --no-fetch` did absolutely nothing, and `leftwm-theme update --no-list` was still listing the themes after fetching.

I suspect that `leftwm-theme update --no-fetch` is redundant with `leftwm-theme list` (all it does is list the themes) but that is another matter.