### PR TITLE
Remove the --no-fetch flag from leftwm-theme update

### DIFF
--- a/src/operations/update.rs
+++ b/src/operations/update.rs
@@ -6,65 +6,64 @@ use log::trace;
 
 #[derive(Clap, Debug)]
 pub struct Update {
-    /// Don't fetch themes
-    #[clap(short = 'n', long)]
-    pub no_fetch: bool,
-
     /// Don't list themes
     #[clap(short = 'f', long)]
     pub no_list: bool,
 }
 
 impl Update {
+    /// Fetch themes from the themes repository.
+    ///
     /// # Errors
     ///
     /// Will error if config cannot be saved
     /// Will error if upstream known.toml cannot be retrieved.
     /// Will error if TOML files themes.toml or known.toml cannot be parsed.
     pub fn exec(&self, config: &mut Config) -> Result<(), errors::LeftError> {
-        if !self.no_fetch {
-            println!("{}", "Fetching themes . . . ".bright_blue().bold());
-            //attempt to fetch new themes
-            trace!("{:?}", &config);
-            for repo in &mut config.repos {
-                if repo.name != "LOCAL" {
-                    println!("    Retrieving themes from {:?}", repo.name);
-                    let resp = reqwest::blocking::get(&repo.url)?.text_with_charset("utf-8")?;
-                    trace!("{:?}", &resp);
+        println!("{}", "Fetching themes . . . ".bright_blue().bold());
+        // Attempt to fetch new themes
+        trace!("{:?}", &config);
+        for repo in &mut config.repos {
+            if repo.name != "LOCAL" {
+                println!("    Retrieving themes from {:?}", repo.name);
+                let resp = reqwest::blocking::get(&repo.url)?.text_with_charset("utf-8")?;
+                trace!("{:?}", &resp);
 
-                    //compare to old themes
-                    repo.compare(toml::from_str(&resp)?)?;
-                }
+                // Compare to old themes
+                repo.compare(toml::from_str(&resp)?)?;
             }
-            Config::save(&config)?;
+        }
+        Config::save(&config)?;
+
+        // Exit early if --no-list was passed
+        if self.no_list {
+            return Ok(());
         }
 
-        if !self.no_fetch {
-            //List themes
-            println!("{}", "\nAvailable themes:".bright_blue().bold());
+        // List themes
+        println!("{}", "\nAvailable themes:".bright_blue().bold());
 
-            for repo in &mut config.repos {
-                for theme in &mut repo.themes {
-                    let current = match theme.current {
-                        Some(true) => "Current: ".bright_green().bold(),
-                        _ => "".white(),
-                    };
-                    let installed = match theme.directory {
-                        Some(_) => "-Installed".red().bold(),
-                        None => "".white(),
-                    };
-                    println!(
-                        "   {}{}/{}: {}{}",
-                        current,
-                        repo.name.bright_magenta().bold(),
-                        theme.name.bright_green().bold(),
-                        theme
-                            .description
-                            .as_ref()
-                            .unwrap_or(&"A LeftWM theme".to_string()),
-                        installed
-                    );
-                }
+        for repo in &mut config.repos {
+            for theme in &mut repo.themes {
+                let current = match theme.current {
+                    Some(true) => "Current: ".bright_green().bold(),
+                    _ => "".white(),
+                };
+                let installed = match theme.directory {
+                    Some(_) => "-Installed".red().bold(),
+                    None => "".white(),
+                };
+                println!(
+                    "   {}{}/{}: {}{}",
+                    current,
+                    repo.name.bright_magenta().bold(),
+                    theme.name.bright_green().bold(),
+                    theme
+                        .description
+                        .as_ref()
+                        .unwrap_or(&"A LeftWM theme".to_string()),
+                    installed
+                );
             }
         }
 


### PR DESCRIPTION
The behavior of `leftwm-theme update --no-fetch` was basically just a worse version of `leftwm-theme list`, so this removes it as redundant.

Closes #10, since this removes the bugged `if` entirely.