### PR TITLE
apply: fix the error message to install first before apply

### DIFF
--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -98,7 +98,7 @@ impl Apply {
                 Ok(())
             } else {
                 error!(
-                    "\nTheme not installed. Try installing it with `leftwm-theme add {}`.",
+                    "\nTheme not installed. Try installing it with `leftwm-theme install {}`.",
                     &self.name
                 );
                 Err(errors::LeftError::from("Theme not installed"))


### PR DESCRIPTION
Subcommand `add` is now `install`. Fix the error message to the new
subcommand.