### PR TITLE
update: Populate local themes repo as well

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -64,7 +64,7 @@ fn main() {
     pretty_env_logger::init();
 
     log::trace!("Loading configuration");
-    let mut config = Config::load().unwrap_or_default();
+    let mut config = Config::new(None).load().unwrap_or_default();
 
     let wrapper: Result<()> = match opt.operation {
         //Operation::AutoFind(args) => AutoFind::exec(&args),

--- a/src/operations/upgrade.rs
+++ b/src/operations/upgrade.rs
@@ -32,6 +32,7 @@ impl Upgrade {
         //attempt to fetch new themes
         if !self.skipdbupdate {
             println!("{}", "Fetching known themes:".bright_blue().bold());
+            let config_dir = config.get_config_dir()?;
             for repo in &mut config.repos {
                 if repo.name == "LOCAL" {
                     continue;
@@ -45,7 +46,7 @@ impl Upgrade {
                 trace!("{:?}", &resp);
 
                 //compare to old themes
-                repo.compare(toml::from_str(&resp)?)?;
+                repo.compare(toml::from_str(&resp)?, config_dir.clone())?;
             }
             Config::save(config)?;
         }


### PR DESCRIPTION
This updates the `update` subcommand to also update the local themes
repo. After fetching and updating the remote themes in community repo,
it is assumed that the rest of the themes in the themes directory are
local themes and add them to the local repo. It also updates the
`current` attribute of the local theme to the appropriate value if
it's the current theme.

To implement this in a testable and reusable way, the Config type is
modified to include a `config_dir: Option<PathBuf>`. This helps all the
Config methods to share the same config_dir instead of building a new
one in every function. The config_dir is passed to any of the Repo
methods that need to know the config dir.
This helped implement the tests for Config.update_local_repo() which
internally calls Repo.compare() for the local repo by setting the
config dir only once in the Config.
A lot of the recently added methods in Repo are updated to take PathBuf
instead of String. It's easier to pass the config_dir directly without
the need to convert it into a String every time.
Updated all the tests to reflect these changes.

As a result of the Config change, the config loading in main.rs calls
the new constructor `Config::new()` with None. This can be used to
enable passing custom config path in the future if there's a need for it.
But it's very helpful for writing tests involving the Config.

Following output shows how the update commands reads the local
themes after creating a new themes.toml

```console
$  ~ rm ~/.config/leftwm/themes.toml
$  ~ leftwm-theme list

Installed themes:
No themes installed.
$  ~ leftwm-theme update
Fetching themes . . .
    Retrieving themes from "community"

Available themes:
   community/Orange Forest: A LeftWM theme-Installed
   community/Coffee: A LeftWM theme
   community/Soothe: A LeftWM theme-Installed
   community/TNG: A LeftWM theme
   community/Windows XP: A LeftWM theme
   community/Dracula Rounded: A LeftWM theme
   community/Forest: A LeftWM theme-Installed
   community/Ground Zero: A LeftWM theme
   community/Red Moon: A LeftWM theme
   community/Blue Coffee: A LeftWM theme
   community/sunflower: A LeftWM theme
   community/Bumblebee: A LeftWM theme
   community/Changed Sunset: A LeftWM theme
   Current: community/Garden: A LeftWM theme-Installed
   LOCAL/myfoo-theme: A LeftWM theme-Installed
   LOCAL/myfoo theme: A LeftWM theme-Installed
```

**NOTE**: This change may be controversial. I'm still new to rust, happy to change the implementation.