### PR TITLE
Add relative_directory tag

### DIFF
--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -260,6 +260,7 @@ impl Repo {
                 target_theme.commit = theme.commit.clone();
                 target_theme.version = theme.version.clone();
                 target_theme.leftwm_versions = theme.leftwm_versions.clone();
+                target_theme.set_relative_directory(theme.relative_directory.clone());
                 target_theme.dependencies = theme.dependencies.clone();
                 target_theme.directory = theme.directory.clone();
             }

--- a/src/models/theme.rs
+++ b/src/models/theme.rs
@@ -4,15 +4,26 @@ use std::path::PathBuf;
 /// Contains information about a theme contained within themes.toml (or known.toml upstream).
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Theme {
+    /// Name of the theme, must follow arch convention [az-_]
     pub name: String,
+    /// A helpful description of the theme
     pub description: Option<String>,
+    /// (Local) (Managed by leftwm-theme), the local directory where the theme is stored
     pub directory: Option<PathBuf>,
+    /// The git repository where the theme may be downloaded from
     pub repository: Option<String>,
+    /// The commit to use for the theme; can use * for HEAD
     pub commit: Option<String>,
+    /// The version for the theme, incrementing will force updates
     pub version: Option<String>,
+    /// Compatible leftwm versions
     pub leftwm_versions: Option<String>,
+    /// (Local) Whether the theme is the current theme
     pub current: Option<bool>,
+    /// A list of dependencies
     pub dependencies: Option<Vec<DependencyL>>,
+    /// Path to the directory containing up, down, and theme.toml w.r.t. root
+    pub relative_directory: Option<String>,
     #[serde(skip)]
     pub source: Option<String>,
 }
@@ -54,6 +65,7 @@ impl Theme {
             leftwm_versions: Some("*".to_string()),
             dependencies: None,
             current: Some(false),
+            relative_directory: None,
             source: None,
         }
     }
@@ -105,6 +117,16 @@ impl Theme {
     pub fn source(&mut self, name: String) -> &mut Theme {
         self.source = Some(name);
         self
+    }
+
+    /// Sets relative directory; abstracting because behavior might change
+    pub fn set_relative_directory(&mut self, rel_dir: Option<String>){
+        self.relative_directory = rel_dir;
+    }
+
+    /// Gets relative directory; abstracting because behavior might change; <3 JKN MGK
+    pub fn relative_directory(&self) -> Option<String> {
+        self.relative_directory.clone()
     }
 
     pub fn current(&mut self, currency: bool) {

--- a/src/models/theme.rs
+++ b/src/models/theme.rs
@@ -120,7 +120,7 @@ impl Theme {
     }
 
     /// Sets relative directory; abstracting because behavior might change
-    pub fn set_relative_directory(&mut self, rel_dir: Option<String>){
+    pub fn set_relative_directory(&mut self, rel_dir: Option<String>) {
         self.relative_directory = rel_dir;
     }
 

--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -56,7 +56,10 @@ impl Apply {
                     error!("Not all prerequirements passed");
                     return Err(errors::LeftError::from("PreReqs"));
                 }
-                let path = Path::new(theme_dir);
+                let mut path = Path::new(theme_dir).to_path_buf();
+                if let Some(rel_dir) = theme.relative_directory() {
+                    path.push(rel_dir);
+                }
                 trace!("{:?}", &path);
                 match fs::remove_dir_all(&dir) {
                     Ok(_) => {


### PR DESCRIPTION
Howdy,

This PR adds a relative_directory option to known.toml and themes.toml. This allows for themes (e.g. Soothe) to specify an internal (sub) directory for a specific theme. Closes #31 

Tagging @ixzh and leftwm/leftwm#436

Best,
Mautamu