### PR TITLE
Add Theme.apply_changes() for any theme changes

### DIFF
--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -398,9 +398,11 @@ mod test {
         let config_dir = tmpdir.path().to_path_buf();
         let result = Repo::installed_themes(&config_dir);
         assert!(result.is_ok());
+        let mut result_vec = result.unwrap();
+        result_vec.sort();
         assert_eq!(
-            result.unwrap(),
-            vec!["test-theme2".to_string(), "test-theme1".to_string(),],
+            result_vec,
+            vec!["test-theme1".to_string(), "test-theme2".to_string(),],
         );
     }
 

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -9,8 +9,9 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 use xdg::BaseDirectories;
 
+pub const THEMES_DIR: &str = "themes";
+
 const BASE_DIR_PREFIX: &str = "leftwm";
-const THEMES_DIR: &str = "themes";
 const CURRENT_DIR: &str = "current";
 const LOCAL_REPO_NAME: &str = "LOCAL";
 const COMMUNITY_REPO_NAME: &str = "community";
@@ -229,6 +230,9 @@ impl Repo {
 
         // Iterate over all the themes, and update/add if needed.
         for mut tema in themes {
+            // Apply any theme changes before updating or adding it.
+            tema.apply_changes(config_dir)?;
+
             // Check if the theme is already installed and update the theme
             // directory attribute.
             if existing_themes.contains(&tema.name.clone()) {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -2,6 +2,6 @@ mod config;
 mod leftwm;
 mod theme;
 
-pub use config::{Config, Repo};
+pub use config::{Config, Repo, THEMES_DIR};
 pub use leftwm::LeftWm;
 pub use theme::{DependencyL, Theme};


### PR DESCRIPTION
__NOTE__: This is based on the ideas discussed in  #9 to implement a
migration path to fix  issues in the theme definitions of existing themes.
It implements:

>  Write a function that can be called that will move old directory (probably accept either Path or PathBuf) to a new one that matches the name (see install for how that's done).
> -- @mautamu https://github.com/leftwm/leftwm-theme/issues/9#issuecomment-817098792

#23 added name validation for new themes. This change is for migrating
the existing themes. This change doesn't add the `changes` repo field as
discussed in #9 but prepares for the structure to implement it.

This introduces a public method `apply_changes()` on the Theme type
to apply various changes to an existing theme. The theme changes
field will be added later in the Theme struct. This is a preparation
for the theme changes feature.

The first type of change implemented here is the directory rename
change as `Theme::apply_change_rename_dir()`. It takes an old theme name
and a new theme name and renames the theme directory if found. This is
called by `Theme.apply_changes()` when the theme name is not the same
after applying the rename change.

`Theme.get_name()` returns the effectual name of the theme after
applying any rename change. The implementation will change once the
changes fields are added in Theme struct.