### PR TITLE
chore(cargo.toml): update version dependencies for git2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ colored = "2.0.0"
 dirs-next = "2.0.0"
 edit-distance = "2.1.0"
 fuzzy-matcher = "0.3.7"
-git2 = "0.13.17"
+git2 = {version = ">=0.13.17, <=0.15"}
 log = "0.4"
 pretty_env_logger = "0.4.0"
 regex = "1.5.4"


### PR DESCRIPTION
`libgit2` was recently updated to version `1.5`.
In the meantime, this newest version of `libgit2` was made available in Arch repo, which broke ` leftwm-theme ` on Arch.

With this change, `leftwm-theme ` can also be used on systems where only `libgit2 1.5` is available.
