### PR TITLE
fix reload crashing leftwm

### DIFF
--- a/src/operations/apply.rs
+++ b/src/operations/apply.rs
@@ -99,7 +99,7 @@ impl Apply {
                 Config::save(config)?;
                 if !self.no_reset {
                     println!("{}", "Reloading LeftWM.".bright_blue().bold());
-                    Command::new("pkill").arg("leftwm-worker").output()?;
+                    Command::new("leftwm-command").arg("SoftReload").output()?;
                 }
                 Ok(())
             } else {


### PR DESCRIPTION
LeftWM didn't like when `leftwm-worker` is killed and crashes (probably related to https://github.com/leftwm/leftwm/pull/832) but using `leftwm-command SoftReload` is friendlier anyways.